### PR TITLE
Parse source links

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -58,9 +58,16 @@ export interface FunctionReturnValue {
   description?: string;
 }
 
+export interface FunctionSource {
+  file: string;
+  lineStart: number;
+  lineEnd?: number;
+}
+
 export interface Function {
   name: string;
   parent: string;
+  source?: FunctionSource;
   description?: string;
   realms: Array<Realm>;
   arguments?: Array<FunctionArgument>;

--- a/src/wiki-scraper.ts
+++ b/src/wiki-scraper.ts
@@ -242,7 +242,7 @@ export class WikiScraper {
     const name = $('function').attr().name;
     const parent = $('function').attr().parent;
     const description = $('function > description').html();
-    const sourceFile = $('function > file');
+    const $sourceFile = $('function > file');
     const realmsRaw = this.trimMultiLineString($('function > realm').text());
     const realms = this.parseRealms(realmsRaw);
     const args: Array<FunctionArgument> = [];
@@ -308,10 +308,10 @@ export class WikiScraper {
       _function.returnValues = returnValues;
     }
 
-    if (sourceFile.length > 0) {
-      const file = $(sourceFile).text();
+    if ($sourceFile.length > 0) {
+      const file = $sourceFile.text();
 
-      const line = $(sourceFile).attr().line.replace('L', '');
+      const line = $sourceFile.attr().line.replace('L', '');
       const lines = line.split('-');
       const lineStart = lines[0];
       const lineEnd = lines[1];

--- a/src/wiki-scraper.ts
+++ b/src/wiki-scraper.ts
@@ -4,6 +4,7 @@ import pLimit from 'p-limit';
 
 import {
   Function,
+  FunctionSource,
   FunctionArgument,
   FunctionReturnValue,
   Realm,
@@ -241,6 +242,7 @@ export class WikiScraper {
     const name = $('function').attr().name;
     const parent = $('function').attr().parent;
     const description = $('function > description').html();
+    const sourceFile = $('function > file');
     const realmsRaw = this.trimMultiLineString($('function > realm').text());
     const realms = this.parseRealms(realmsRaw);
     const args: Array<FunctionArgument> = [];
@@ -304,6 +306,26 @@ export class WikiScraper {
 
     if (returnValues.length > 0) {
       _function.returnValues = returnValues;
+    }
+
+    if (sourceFile.length > 0) {
+      const file = $(sourceFile).text();
+
+      const line = $(sourceFile).attr().line;
+      const lines = line.split('-L');
+      const lineStart = lines[0];
+      const lineEnd = lines[1];
+
+      const source: FunctionSource = {
+        file: file,
+        lineStart: Number(lineStart),
+      };
+
+      if (lineEnd) {
+        source.lineEnd = Number(lineEnd);
+      }
+
+      _function.source = source;
     }
 
     return _function;

--- a/src/wiki-scraper.ts
+++ b/src/wiki-scraper.ts
@@ -311,8 +311,8 @@ export class WikiScraper {
     if (sourceFile.length > 0) {
       const file = $(sourceFile).text();
 
-      const line = $(sourceFile).attr().line;
-      const lines = line.split('-L');
+      const line = $(sourceFile).attr().line.replace('L', '');
+      const lines = line.split('-');
       const lineStart = lines[0];
       const lineEnd = lines[1];
 


### PR DESCRIPTION
This parses the "View Source" links on pages that have it. It handles single-line and multi-line sources.

Examples in output:
```json
    "source": {
      "file": "lua/includes/util.lua",
      "lineStart": 177,
      "lineEnd": 219
    }
```
```json
    "source": {
      "file": "lua/menu/background.lua",
      "lineStart": 77
    }
```

And is absent for functions that don't have it.